### PR TITLE
Fixed the deploy to gh-pages

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -184,6 +184,7 @@ module.exports = (grunt) ->
 
 			travis:
 				options:
+					repo: "https://" + process.env.GH_TOKEN + "@github.com/wet-boew/wet-boew-styleguide.git"
 					message: "Travis build " + process.env.TRAVIS_BUILD_NUMBER
 					silent: true
 				src: [


### PR DESCRIPTION
Travis clones using a read-only remote. This prevents the default configuration from working. The `repo` option must be used to specify a non-read-only remote that uses the GitHub encrypted token.
