### PR TITLE
The docs should describe website as being one word, not two

### DIFF
--- a/site/pages/v4/writing/formatting-en.hbs
+++ b/site/pages/v4/writing/formatting-en.hbs
@@ -1546,7 +1546,7 @@
   <li><strong>Internet</strong> Initial caps</li>
   <li><strong>intranet</strong> All lowercase</li>
   <li><strong>Web</strong> The word web is only capitalized when it is used in a proper name, such as World Wide Web.</li>
-  <li><strong>website</strong> Two words, lowercase.</li>
+  <li><strong>website</strong> One word, lowercase.</li>
   <li><strong>web application</strong> Two words, lowercase.</li>
   <li><strong>web page</strong> Two words, lowercase.</li>
   <li><strong>web form</strong> Two words, lowercase.</li>


### PR DESCRIPTION
Separately, "web page" is inconsistently one word ("webpage") and two words throughout the style guide.
