### PR TITLE
Breadcrumbs: Override wet-boew template

### DIFF
--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -1,0 +1,6 @@
+{
+	"tmpl-accessibility-guide": "Accessibility guide",
+	"tmpl-design-guide": "Design guide",
+	"tmpl-style-guide": "Style guide",
+	"tmpl-writing-guide": "Writing guide"
+}

--- a/site/includes/breadcrumbs.hbs
+++ b/site/includes/breadcrumbs.hbs
@@ -1,0 +1,31 @@
+<div class="container">
+	<div class="row">
+		<ol class="breadcrumb">
+			<li>
+				<a href="http://wet-boew.github.io/wet-boew/index-{{language}}.html">{{{i18n "tmpl-home"}}}</a>
+			</li>
+			<li>
+				<a href="{{assets}}/index-{{language}}.html">{{{i18n "tmpl-style-guide"}}}</a>
+			</li>
+{{#contains page.src "index"}}
+{{else}}
+	{{#contains page.src "/accessibility/"}}
+			<li>
+				<a href="{{assets}}/accessibility/index-{{language}}.html">{{{i18n "tmpl-accessibility-guide"}}}</a>
+			</li>
+	{{/contains}}
+	{{#contains page.src "/design/"}}
+			<li>
+				<a href="{{assets}}/design/index-{{language}}.html">{{{i18n "tmpl-design-guide"}}}</a>
+			</li>
+	{{/contains}}
+	{{#contains page.src "/writing/"}}
+			<li>
+				<a href="{{assets}}/writing/index-{{language}}.html">{{{i18n "tmpl-writing-guide"}}}</a>
+			</li>
+	{{/contains}}
+{{/contains}}
+			<li>{{title}}</li>
+		</ol>
+	</div>
+</div>


### PR DESCRIPTION
Adds landing pages for separate guides and removes the "Working Examples" from the path. I stubbed in the i18n stuff even though we don't have the French templates right now.

Fixes gh-112
