### PR TITLE
Removes title attribute from blockquote cite example. Fixes #70.

### DIFF
--- a/site/pages/v4/design/quotations-en.hbs
+++ b/site/pages/v4/design/quotations-en.hbs
@@ -81,13 +81,13 @@
 
 			<blockquote>
 				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
-				<footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
+				<footer>Someone famous in <cite>Source Title</cite></footer>
 			</blockquote>
 
 			<div class="mrgn-tp-lg">
 				<pre><code>&lt;blockquote&gt;
 	&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.&lt;/p&gt;
-	&lt;footer&gt;Someone famous in &lt;cite title="Source Title"&gt;Source Title&lt;/cite&gt;&lt;/footer&gt;
+	&lt;footer&gt;Someone famous in &lt;cite&gt;Source Title&lt;/cite&gt;&lt;/footer&gt;
 &lt;/blockquote&gt;</code></pre>
 			</div>
 
@@ -138,7 +138,7 @@
 <section>
     <h2 class="page-header" id="inline">Inline quotes</h2>
     <p>For phrasing content quoted from another source. Use <code>&lt;q&gt;</code> if a quotation is short and appears within a paragraph.</p>
-	
+
 	<p>"<q>Our Government is committed to protecting livestock health</q>" said Minister Ritz.</p>
 
 	<div class="mrgn-tp-lg">


### PR DESCRIPTION
Fixed as per Thomas' direction (Issue https://github.com/wet-boew/wet-boew-styleguide/issues/70).
cc/ @cfarquharson @thomasgohard @bsouster