### PR TITLE
Build: Updated grunt-sass dependency to ^1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-gh-pages": "^0.9.1",
     "grunt-hub": "~0.7.0",
     "grunt-install-dependencies": "^0.2.0",
-    "grunt-sass": "~0.14.0",
+    "grunt-sass": "^1.0.0",
     "time-grunt": "^1.0.0"
   }
 }


### PR DESCRIPTION
Same version wet-boew/wet-boew currently uses. Needed to setup the build system in node 0.12.x (and probably 4.x and up).