### PR TITLE
Firefox 30 button bug

### DIFF
--- a/site/pages/v4/design/buttons-en.hbs
+++ b/site/pages/v4/design/buttons-en.hbs
@@ -103,7 +103,7 @@
       <ul>
         <li><strong>Use the <code>&lt;button&gt;</code> element whenever possible</strong> to ensure matching cross-browser rendering
           <ul>
-            <li>There is <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451" >a Firefox bug</a> that makes it impossible to set the <code>line-height</code> in <code>&lt;input&gt;</code>-based buttons</li>
+            <li>There is <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451" >a bug in Firefox <30</a> that makes it impossible to set the <code>line-height</code> in <code>&lt;input&gt;</code>-based buttons</li>
             <li>These buttons therefore have uneven heights in Firefox</li>
           </ul>
         </li>

--- a/site/pages/v4/design/buttons-en.hbs
+++ b/site/pages/v4/design/buttons-en.hbs
@@ -103,7 +103,7 @@
       <ul>
         <li><strong>Use the <code>&lt;button&gt;</code> element whenever possible</strong> to ensure matching cross-browser rendering
           <ul>
-            <li>There is <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451" >a bug in Firefox <30</a> that makes it impossible to set the <code>line-height</code> in <code>&lt;input&gt;</code>-based buttons</li>
+            <li>There is <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451" >a bug in Firefox &lt;30</a> that makes it impossible to set the <code>line-height</code> in <code>&lt;input&gt;</code>-based buttons</li>
             <li>These buttons therefore have uneven heights in Firefox</li>
           </ul>
         </li>

--- a/site/pages/v4/design/buttons-fr.hbs
+++ b/site/pages/v4/design/buttons-fr.hbs
@@ -103,7 +103,7 @@
       <ul>
         <li><strong>Utilisez l'élément  <code>&lt;button&gt;</code> tant que possible</strong> afin de vous assurer  de la concordance avec le rendu multinavigateur
               <ul>
-            <li>Il y a un<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451" > bogue dans  Firefox </a> that qui rend impossible l'établissement de  <code>line-height</code> dans les boutons fondés sur <code>&lt;input&gt;</code></li>
+            <li>Il y a un<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=697451" > bogue dans  Firefox &lt;30</a> that qui rend impossible l'établissement de  <code>line-height</code> dans les boutons fondés sur <code>&lt;input&gt;</code></li>
             <li>La hauteur de ces boutons est inégale dans Firefox</li>
           </ul>
         </li>


### PR DESCRIPTION
From the discussion here:  https://github.com/wet-boew/wet-boew/issues/7744#issuecomment-259571971

The bug has been fixed in Firefox 30+ and this change reflects the change that Bootstrap made to their documentation.

The newline-at-end-of-file difference is an artifact of editing the files on the GitHub website... is that OK?