### PR TITLE
Fix link to wells

### DIFF
--- a/site/pages/v4/design/borders-en.hbs
+++ b/site/pages/v4/design/borders-en.hbs
@@ -204,7 +204,7 @@
     </div>
   </div>
   <h4 id="radius"><span class="fa-stack"><span class="fa fa-circle fa-stack-2x"></span><span class="fa fa-stack-1x fa-inverse">&lceil;</span></span> Remove border radius</h4>
-  <p>Use to remove the border radius from a design component, like a <a href="well-en.html">well</a>.</p>
+  <p>Use to remove the border radius from a design component, like a <a href="wells-en.html">well</a>.</p>
   <div class="row">
     <div class="col-md-4">
       <div class="panel panel-default">

--- a/site/pages/v4/design/borders-fr.hbs
+++ b/site/pages/v4/design/borders-fr.hbs
@@ -209,7 +209,7 @@
     </div>
   </div>
   <h4 id="radius"><span class="fa-stack"><span class="fa fa-circle fa-stack-2x"></span><span class="fa fa-stack-1x fa-inverse">&lceil;</span></span> Retirer un rayon de bordure </h4>
-  <p>Utilisez pour retirer le rayon de bordure à partir d'une composante de conception, comme un <a href="well-en.html">puits</a>.</p>
+  <p>Utilisez pour retirer le rayon de bordure à partir d'une composante de conception, comme un <a href="wells-fr.html">puits</a>.</p>
   <div class="row">
     <div class="col-md-4">
       <div class="panel panel-default">


### PR DESCRIPTION
The link to the 'Wells' page was pointing to `well-en.html` in both English and French.  It should be "wells", not "well".

Again, the unrelated new-line-at-end-of-file change is just an artifact of editing the files on the GitHub web page... don't know a way of not including that.