### PR TITLE
Build: Updated grunt-gh-pages to version ~2.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-csslint": "~0.2.0",
     "grunt-contrib-cssmin": "^0.9.0",
-    "grunt-gh-pages": "^0.9.1",
+    "grunt-gh-pages": "^2.0.0",
     "grunt-hub": "~0.7.0",
     "grunt-install-dependencies": "^0.2.0",
     "grunt-sass": "^1.0.0",


### PR DESCRIPTION
All 1.x versions of it use a dependency called wrench, which is incompatible with node.js >=7.x. Starting with version 2.0.0, its wrench dependency has been replaced with fs-extra (which works properly in node.js >=7.x).