### PR TITLE
Icons: Updated Glyphicons links to point to Bootstrap 3.3.1 docs.

### DIFF
--- a/site/pages/v4/design/icons-en.hbs
+++ b/site/pages/v4/design/icons-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"altLangPrefix": "icons",
 	"css": ["https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome"],
-	"dateModified": "2016-10-17"
+	"dateModified": "2017-06-05"
 }
 ---
 
@@ -72,7 +72,7 @@
   </div>
   <h3 id="gly">Glyphicons</h3>
   <p>Glyphicons provides 250 glyphs. This is part of the <abbr title="Web Experience Toolkit">WET</abbr> core build. </p>
-  <p><a href="http://getbootstrap.com/components/#glyphicons"  class="btn btn-primary" >View Glyphicons</a></p>
+  <p><a href="http://bootstrapdocs.com/v3.3.1/docs/components/#glyphicons"  class="btn btn-primary" >View Glyphicons</a></p>
   <h3 id="fon">Font Awesome icons</h3>
   <p>Font Awesome provides 600+ glyphs. These icons are <strong>not</strong> part of the <abbr title="Web Experience Toolkit">WET</abbr> core build. Simply add this code within the <code>&lt;head&gt;</code> of the page: <code>&lt;link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet"&gt;</code></p>
   <p><a href="http://fortawesome.github.io/Font-Awesome/icons/" class="btn btn-primary"  >View Font Awesome icons</a> <a href="http://fortawesome.github.io/Font-Awesome/examples/"  class="btn btn-primary">View Font Awesome stacking, resizing, rotating, spinning icon examples</a></p>

--- a/site/pages/v4/design/icons-fr.hbs
+++ b/site/pages/v4/design/icons-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"altLangPrefix": "icons",
 	"css": ["https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome"],
-	"dateModified": "2016-10-17"
+	"dateModified": "2017-06-05"
 }
 ---
 
@@ -72,7 +72,7 @@
   </div>
   <h3 id="gly"><span lang="en">Glyphicons</span></h3>
   <p>Les <span lang="en">Glyphicons</span> donnent 250 glyphes. Elles font partie de la version de base de la <abbr title="Boîte à outils de l'expérience Web">BOEW</abbr>. </p>
-  <p><a href="http://getbootstrap.com/components/#glyphicons" class="btn btn-primary">Afficher les <span lang="en">Glyphicons</span></a></p>
+  <p><a href="http://bootstrapdocs.com/v3.3.1/docs/components/#glyphicons" class="btn btn-primary">Afficher les <span lang="en">Glyphicons</span></a></p>
   <h3 id="fon">Icônes de police <span lang="en">Font Awesome</span> </h3>
   <p>La police <span lang="en">Font Awesome</span> contient plus de 600 glyphes. Ces icônes <strong>ne font pas</strong> partie de   la version de base de la <abbr title="Boîte à outils de l'expérience Web">BOEW</abbr>. Ajoutez simplement ces codes dans <code>&lt;head&gt;</code> de la page&nbsp;: <code>&lt;link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet"&gt;</code></p>
   <p><a href="http://fortawesome.github.io/Font-Awesome/icons/" class="btn btn-primary">Afficher les icônes de police <span lang="en">Font Awesome</span></a> <a href="http://fortawesome.github.io/Font-Awesome/examples/"  class="btn btn-primary">Afficher des exemples d'icône de police <span lang="en">Font Awesome</span> – Empiler, redimensionner, pivoter, tourner </a></p>


### PR DESCRIPTION
Those links previously pointed to the Glyphicons section in the latest version of Bootstrap's documentation. However, this was misleading since newer versions of Bootstrap contain more glyphs than the older version of Bootstrap WET currently uses.

WET currently uses Bootstrap 3.3.1, which contains 200 glyphs. Bootstrap itself is currently at version 3.3.7, which contains 250 glyphs.